### PR TITLE
Automation: Create allure report per stand and branch

### DIFF
--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -5,9 +5,6 @@ on:
     - cron: "0 0,3 * * *"
   workflow_dispatch:
     inputs:
-      tags:
-        description: "Test scenario tags"
-        required: false
       network:
         type: choice
         default: teststand2
@@ -26,6 +23,9 @@ on:
         description: "Number of jobs in GNU Parallel"
         required: true
         default: "8"
+      tags:
+        description: "Test scenario tags"
+        required: false
 
 env:
   JOBS_NUMBER: "8"
@@ -263,6 +263,24 @@ jobs:
           ref: gh-pages
           path: gh-pages
 
+      - name: Create a path for report
+        run: |
+          path=""
+          network="${{ github.event.inputs.network }}"
+          ref_name="${{ github.ref_name }}"
+          if [[ "$network" != "teststand2" ]]; then
+            path="$network"
+          fi
+          if [[ "$ref_name" != "develop" ]]; then
+            if [ ${#path} -gt 0 ]; then
+              path="$path/$ref_name"
+            else
+              path="$ref_name"
+            fi
+          fi
+          echo "ALLURE_SUBDIR=$path" >> $GITHUB_ENV
+
+
       # - name: Allure Report with history
       #   # uses: simple-elf/allure-report-action@v1.5
       #   uses: simple-elf/allure-report-action@master
@@ -274,7 +292,7 @@ jobs:
         with:
           allure_results: allure-results
           gh_pages: gh-pages
-          subfolder: "${{ github.event.inputs.network == 'teststand2' && '' || github.event.inputs.network }}/${{ github.ref_name == 'develop' && '' || github.ref_name }}"
+          subfolder: ${{ env.ALLURE_SUBDIR }}
           allure_report: allure-report
           allure_history: allure-history
           keep_reports: 50

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -63,132 +63,132 @@ jobs:
         with:
           folder-name: report/allure-results
 
-  node-contracts-01:
-    runs-on: macos-11
-    timeout-minutes: 361
-    steps:
-      - uses: actions/checkout@v2
-      # TODO: de-duplicate it https://github.com/neonlabsorg/neon-compatibility/issues/155
-      - name: Display input parameters
-        run: |
-          if [ -n "${{ github.event.inputs.jobsNumber }}" ]; then
-            echo "JOBS_NUMBER=${{ github.event.inputs.jobsNumber }}" >> $GITHUB_ENV
-          fi
-          echo "cat $GITHUB_ENV"
-          cat $GITHUB_ENV
-        shell: bash
-      # macos-11
-      # - uses: ./.github/actions/allure-prep
-      - uses: ./.github/actions/openzeppelin-preparation
-      - uses: ./.github/actions/switch-network
-        if: always()
-      - uses: ./.github/actions/allure-environment-data
-        if: always()
-      - name: Use Node.js 16
-        uses: actions/setup-node@v2
-        if: always()
-        with:
-          node-version: 16.x
-          cache: "npm"
-      - run: npm ci
-      - run: npm run build --if-present
-      - uses: ./.github/actions/install-parallel-solc
-        if: always()
-      - uses: ./.github/actions/run-process-upload
-        if: always()
-        timeout-minutes: 60
-        with:
-          folder-name: access
-          jobsNumber: $JOBS_NUMBER
-
-      - uses: ./.github/actions/run-process-upload
-        if: always()
-        timeout-minutes: 60
-        with:
-          folder-name: finance
-          jobsNumber: $JOBS_NUMBER
-
-      - uses: ./.github/actions/run-process-upload
-        if: always()
-        timeout-minutes: 60
-        with:
-          folder-name: governance
-          jobsNumber: $JOBS_NUMBER
-
-      - uses: ./.github/actions/run-process-upload
-        if: always()
-        timeout-minutes: 60
-        with:
-          folder-name: helpers
-          jobsNumber: $JOBS_NUMBER
-
-      - uses: ./.github/actions/run-process-upload
-        if: always()
-        timeout-minutes: 60
-        with:
-          folder-name: metatx
-          jobsNumber: $JOBS_NUMBER
-
-      - uses: ./.github/actions/run-process-upload
-        if: always()
-        timeout-minutes: 60
-        with:
-          folder-name: proxy
-          jobsNumber: $JOBS_NUMBER
-
-      - uses: ./.github/actions/run-process-upload
-        if: always()
-        timeout-minutes: 60
-        with:
-          folder-name: security
-          jobsNumber: $JOBS_NUMBER
-
-  node-contracts-02:
-    runs-on: macos-11
-    timeout-minutes: 361
-    if: always()
-    needs: node-contracts-01
-    steps:
-      - uses: actions/checkout@v2
-      # TODO: de-duplicate it https://github.com/neonlabsorg/neon-compatibility/issues/155
-      - name: Display input parameters
-        run: |
-          if [ -n "${{ github.event.inputs.jobsNumber }}" ]; then
-            echo "JOBS_NUMBER=${{ github.event.inputs.jobsNumber }}" >> $GITHUB_ENV
-          fi
-          echo "cat $GITHUB_ENV"
-          cat $GITHUB_ENV
-        shell: bash
-      # macos-11
-      # - uses: ./.github/actions/allure-prep
-      - uses: ./.github/actions/openzeppelin-preparation
-      - uses: ./.github/actions/switch-network
-        if: always()
-      - uses: ./.github/actions/allure-environment-data
-        if: always()
-      - name: Use Node.js 16
-        uses: actions/setup-node@v2
-        if: always()
-        with:
-          node-version: 16.x
-          cache: "npm"
-      - run: npm ci
-      - run: npm run build --if-present
-      - uses: ./.github/actions/install-parallel-solc
-        if: always()
-      - uses: ./.github/actions/run-process-upload
-        if: always()
-        timeout-minutes: 180
-        with:
-          folder-name: token
-          jobsNumber: $JOBS_NUMBER
-
-      - uses: ./.github/actions/run-process-upload
-        if: always()
-        timeout-minutes: 60
-        with:
-          folder-name: utils
-          jobsNumber: $JOBS_NUMBER
+#  node-contracts-01:
+#    runs-on: macos-11
+#    timeout-minutes: 361
+#    steps:
+#      - uses: actions/checkout@v2
+#      # TODO: de-duplicate it https://github.com/neonlabsorg/neon-compatibility/issues/155
+#      - name: Display input parameters
+#        run: |
+#          if [ -n "${{ github.event.inputs.jobsNumber }}" ]; then
+#            echo "JOBS_NUMBER=${{ github.event.inputs.jobsNumber }}" >> $GITHUB_ENV
+#          fi
+#          echo "cat $GITHUB_ENV"
+#          cat $GITHUB_ENV
+#        shell: bash
+#      # macos-11
+#      # - uses: ./.github/actions/allure-prep
+#      - uses: ./.github/actions/openzeppelin-preparation
+#      - uses: ./.github/actions/switch-network
+#        if: always()
+#      - uses: ./.github/actions/allure-environment-data
+#        if: always()
+#      - name: Use Node.js 16
+#        uses: actions/setup-node@v2
+#        if: always()
+#        with:
+#          node-version: 16.x
+#          cache: "npm"
+#      - run: npm ci
+#      - run: npm run build --if-present
+#      - uses: ./.github/actions/install-parallel-solc
+#        if: always()
+#      - uses: ./.github/actions/run-process-upload
+#        if: always()
+#        timeout-minutes: 60
+#        with:
+#          folder-name: access
+#          jobsNumber: $JOBS_NUMBER
+#
+#      - uses: ./.github/actions/run-process-upload
+#        if: always()
+#        timeout-minutes: 60
+#        with:
+#          folder-name: finance
+#          jobsNumber: $JOBS_NUMBER
+#
+#      - uses: ./.github/actions/run-process-upload
+#        if: always()
+#        timeout-minutes: 60
+#        with:
+#          folder-name: governance
+#          jobsNumber: $JOBS_NUMBER
+#
+#      - uses: ./.github/actions/run-process-upload
+#        if: always()
+#        timeout-minutes: 60
+#        with:
+#          folder-name: helpers
+#          jobsNumber: $JOBS_NUMBER
+#
+#      - uses: ./.github/actions/run-process-upload
+#        if: always()
+#        timeout-minutes: 60
+#        with:
+#          folder-name: metatx
+#          jobsNumber: $JOBS_NUMBER
+#
+#      - uses: ./.github/actions/run-process-upload
+#        if: always()
+#        timeout-minutes: 60
+#        with:
+#          folder-name: proxy
+#          jobsNumber: $JOBS_NUMBER
+#
+#      - uses: ./.github/actions/run-process-upload
+#        if: always()
+#        timeout-minutes: 60
+#        with:
+#          folder-name: security
+#          jobsNumber: $JOBS_NUMBER
+#
+#  node-contracts-02:
+#    runs-on: macos-11
+#    timeout-minutes: 361
+#    if: always()
+#    needs: node-contracts-01
+#    steps:
+#      - uses: actions/checkout@v2
+#      # TODO: de-duplicate it https://github.com/neonlabsorg/neon-compatibility/issues/155
+#      - name: Display input parameters
+#        run: |
+#          if [ -n "${{ github.event.inputs.jobsNumber }}" ]; then
+#            echo "JOBS_NUMBER=${{ github.event.inputs.jobsNumber }}" >> $GITHUB_ENV
+#          fi
+#          echo "cat $GITHUB_ENV"
+#          cat $GITHUB_ENV
+#        shell: bash
+#      # macos-11
+#      # - uses: ./.github/actions/allure-prep
+#      - uses: ./.github/actions/openzeppelin-preparation
+#      - uses: ./.github/actions/switch-network
+#        if: always()
+#      - uses: ./.github/actions/allure-environment-data
+#        if: always()
+#      - name: Use Node.js 16
+#        uses: actions/setup-node@v2
+#        if: always()
+#        with:
+#          node-version: 16.x
+#          cache: "npm"
+#      - run: npm ci
+#      - run: npm run build --if-present
+#      - uses: ./.github/actions/install-parallel-solc
+#        if: always()
+#      - uses: ./.github/actions/run-process-upload
+#        if: always()
+#        timeout-minutes: 180
+#        with:
+#          folder-name: token
+#          jobsNumber: $JOBS_NUMBER
+#
+#      - uses: ./.github/actions/run-process-upload
+#        if: always()
+#        timeout-minutes: 60
+#        with:
+#          folder-name: utils
+#          jobsNumber: $JOBS_NUMBER
 
   node:
     runs-on: ubuntu-latest
@@ -238,7 +238,7 @@ jobs:
     timeout-minutes: 15
     if: always()
     needs:
-      - node-contracts-02
+#      - node-contracts-02
       - python
       - node
     steps:
@@ -263,7 +263,7 @@ jobs:
         if: always()
         with:
           allure_results: allure-results
-          gh_pages: gh-pages
+          gh_pages: gh-pages/report
           allure_report: allure-report
           allure_history: allure-history
           keep_reports: 50

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -305,6 +305,17 @@ jobs:
           PUBLISH_BRANCH: gh-pages
           PUBLISH_DIR: allure-history
 
+      - name: Post the link to the report
+        if: always()
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: 'Run tests on stand'
+          state: 'success'
+          sha: ${{ github.event.pull_request.head.sha }}
+          target_url: https://docs.neon-labs.org/neon-compatibility/${{ env.ALLURE_SUBDIR }}
+
+
   notification:
     runs-on: ubuntu-latest
     if: always()

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -73,132 +73,132 @@ jobs:
         with:
           folder-name: report/allure-results
 
-#  node-contracts-01:
-#    runs-on: macos-11
-#    timeout-minutes: 361
-#    steps:
-#      - uses: actions/checkout@v2
-#      # TODO: de-duplicate it https://github.com/neonlabsorg/neon-compatibility/issues/155
-#      - name: Display input parameters
-#        run: |
-#          if [ -n "${{ github.event.inputs.jobsNumber }}" ]; then
-#            echo "JOBS_NUMBER=${{ github.event.inputs.jobsNumber }}" >> $GITHUB_ENV
-#          fi
-#          echo "cat $GITHUB_ENV"
-#          cat $GITHUB_ENV
-#        shell: bash
-#      # macos-11
-#      # - uses: ./.github/actions/allure-prep
-#      - uses: ./.github/actions/openzeppelin-preparation
-#      - uses: ./.github/actions/switch-network
-#        if: always()
-#      - uses: ./.github/actions/allure-environment-data
-#        if: always()
-#      - name: Use Node.js 16
-#        uses: actions/setup-node@v2
-#        if: always()
-#        with:
-#          node-version: 16.x
-#          cache: "npm"
-#      - run: npm ci
-#      - run: npm run build --if-present
-#      - uses: ./.github/actions/install-parallel-solc
-#        if: always()
-#      - uses: ./.github/actions/run-process-upload
-#        if: always()
-#        timeout-minutes: 60
-#        with:
-#          folder-name: access
-#          jobsNumber: $JOBS_NUMBER
-#
-#      - uses: ./.github/actions/run-process-upload
-#        if: always()
-#        timeout-minutes: 60
-#        with:
-#          folder-name: finance
-#          jobsNumber: $JOBS_NUMBER
-#
-#      - uses: ./.github/actions/run-process-upload
-#        if: always()
-#        timeout-minutes: 60
-#        with:
-#          folder-name: governance
-#          jobsNumber: $JOBS_NUMBER
-#
-#      - uses: ./.github/actions/run-process-upload
-#        if: always()
-#        timeout-minutes: 60
-#        with:
-#          folder-name: helpers
-#          jobsNumber: $JOBS_NUMBER
-#
-#      - uses: ./.github/actions/run-process-upload
-#        if: always()
-#        timeout-minutes: 60
-#        with:
-#          folder-name: metatx
-#          jobsNumber: $JOBS_NUMBER
-#
-#      - uses: ./.github/actions/run-process-upload
-#        if: always()
-#        timeout-minutes: 60
-#        with:
-#          folder-name: proxy
-#          jobsNumber: $JOBS_NUMBER
-#
-#      - uses: ./.github/actions/run-process-upload
-#        if: always()
-#        timeout-minutes: 60
-#        with:
-#          folder-name: security
-#          jobsNumber: $JOBS_NUMBER
-#
-#  node-contracts-02:
-#    runs-on: macos-11
-#    timeout-minutes: 361
-#    if: always()
-#    needs: node-contracts-01
-#    steps:
-#      - uses: actions/checkout@v2
-#      # TODO: de-duplicate it https://github.com/neonlabsorg/neon-compatibility/issues/155
-#      - name: Display input parameters
-#        run: |
-#          if [ -n "${{ github.event.inputs.jobsNumber }}" ]; then
-#            echo "JOBS_NUMBER=${{ github.event.inputs.jobsNumber }}" >> $GITHUB_ENV
-#          fi
-#          echo "cat $GITHUB_ENV"
-#          cat $GITHUB_ENV
-#        shell: bash
-#      # macos-11
-#      # - uses: ./.github/actions/allure-prep
-#      - uses: ./.github/actions/openzeppelin-preparation
-#      - uses: ./.github/actions/switch-network
-#        if: always()
-#      - uses: ./.github/actions/allure-environment-data
-#        if: always()
-#      - name: Use Node.js 16
-#        uses: actions/setup-node@v2
-#        if: always()
-#        with:
-#          node-version: 16.x
-#          cache: "npm"
-#      - run: npm ci
-#      - run: npm run build --if-present
-#      - uses: ./.github/actions/install-parallel-solc
-#        if: always()
-#      - uses: ./.github/actions/run-process-upload
-#        if: always()
-#        timeout-minutes: 180
-#        with:
-#          folder-name: token
-#          jobsNumber: $JOBS_NUMBER
-#
-#      - uses: ./.github/actions/run-process-upload
-#        if: always()
-#        timeout-minutes: 60
-#        with:
-#          folder-name: utils
-#          jobsNumber: $JOBS_NUMBER
+  node-contracts-01:
+    runs-on: macos-11
+    timeout-minutes: 361
+    steps:
+      - uses: actions/checkout@v2
+      # TODO: de-duplicate it https://github.com/neonlabsorg/neon-compatibility/issues/155
+      - name: Display input parameters
+        run: |
+          if [ -n "${{ github.event.inputs.jobsNumber }}" ]; then
+            echo "JOBS_NUMBER=${{ github.event.inputs.jobsNumber }}" >> $GITHUB_ENV
+          fi
+          echo "cat $GITHUB_ENV"
+          cat $GITHUB_ENV
+        shell: bash
+      # macos-11
+      # - uses: ./.github/actions/allure-prep
+      - uses: ./.github/actions/openzeppelin-preparation
+      - uses: ./.github/actions/switch-network
+        if: always()
+      - uses: ./.github/actions/allure-environment-data
+        if: always()
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        if: always()
+        with:
+          node-version: 16.x
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build --if-present
+      - uses: ./.github/actions/install-parallel-solc
+        if: always()
+      - uses: ./.github/actions/run-process-upload
+        if: always()
+        timeout-minutes: 60
+        with:
+          folder-name: access
+          jobsNumber: $JOBS_NUMBER
+
+      - uses: ./.github/actions/run-process-upload
+        if: always()
+        timeout-minutes: 60
+        with:
+          folder-name: finance
+          jobsNumber: $JOBS_NUMBER
+
+      - uses: ./.github/actions/run-process-upload
+        if: always()
+        timeout-minutes: 60
+        with:
+          folder-name: governance
+          jobsNumber: $JOBS_NUMBER
+
+      - uses: ./.github/actions/run-process-upload
+        if: always()
+        timeout-minutes: 60
+        with:
+          folder-name: helpers
+          jobsNumber: $JOBS_NUMBER
+
+      - uses: ./.github/actions/run-process-upload
+        if: always()
+        timeout-minutes: 60
+        with:
+          folder-name: metatx
+          jobsNumber: $JOBS_NUMBER
+
+      - uses: ./.github/actions/run-process-upload
+        if: always()
+        timeout-minutes: 60
+        with:
+          folder-name: proxy
+          jobsNumber: $JOBS_NUMBER
+
+      - uses: ./.github/actions/run-process-upload
+        if: always()
+        timeout-minutes: 60
+        with:
+          folder-name: security
+          jobsNumber: $JOBS_NUMBER
+
+  node-contracts-02:
+    runs-on: macos-11
+    timeout-minutes: 361
+    if: always()
+    needs: node-contracts-01
+    steps:
+      - uses: actions/checkout@v2
+      # TODO: de-duplicate it https://github.com/neonlabsorg/neon-compatibility/issues/155
+      - name: Display input parameters
+        run: |
+          if [ -n "${{ github.event.inputs.jobsNumber }}" ]; then
+            echo "JOBS_NUMBER=${{ github.event.inputs.jobsNumber }}" >> $GITHUB_ENV
+          fi
+          echo "cat $GITHUB_ENV"
+          cat $GITHUB_ENV
+        shell: bash
+      # macos-11
+      # - uses: ./.github/actions/allure-prep
+      - uses: ./.github/actions/openzeppelin-preparation
+      - uses: ./.github/actions/switch-network
+        if: always()
+      - uses: ./.github/actions/allure-environment-data
+        if: always()
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        if: always()
+        with:
+          node-version: 16.x
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build --if-present
+      - uses: ./.github/actions/install-parallel-solc
+        if: always()
+      - uses: ./.github/actions/run-process-upload
+        if: always()
+        timeout-minutes: 180
+        with:
+          folder-name: token
+          jobsNumber: $JOBS_NUMBER
+
+      - uses: ./.github/actions/run-process-upload
+        if: always()
+        timeout-minutes: 60
+        with:
+          folder-name: utils
+          jobsNumber: $JOBS_NUMBER
 
   node:
     runs-on: ubuntu-latest
@@ -248,7 +248,7 @@ jobs:
     timeout-minutes: 15
     if: always()
     needs:
-#      - node-contracts-02
+      - node-contracts-02
       - python
       - node
     steps:
@@ -304,17 +304,6 @@ jobs:
           PERSONAL_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_BRANCH: gh-pages
           PUBLISH_DIR: allure-history
-
-      - name: Post the link to the report
-        if: always()
-        uses: Sibz/github-status-action@v1
-        with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
-          context: 'Run tests on stand'
-          state: 'success'
-          sha: ${{ github.event.pull_request.head.sha }}
-          target_url: https://docs.neon-labs.org/neon-compatibility/${{ env.ALLURE_SUBDIR }}
-
 
   notification:
     runs-on: ubuntu-latest

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -10,7 +10,7 @@ on:
         required: false
       network:
         type: choice
-        default: "teststand2"
+        default: teststand2
         required: true
         description: "Network (devnet, testnet, teststand, teststand2, neonswap.live, aws, ropsten, rinkeby)"
         choices:

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -274,7 +274,7 @@ jobs:
         with:
           allure_results: allure-results
           gh_pages: gh-pages
-          subfolder: "${{ github.event.inputs.network == 'teststand2' && '' || github.event.inputs.network }}${{ github.ref_name == 'develop' && '' || '/${{ github.ref_name}}' }}"
+          subfolder: "${{ github.event.inputs.network == 'teststand2' && '' || github.event.inputs.network }}/${{ github.ref_name == 'develop' && '' || github.ref_name }}"
           allure_report: allure-report
           allure_history: allure-history
           keep_reports: 50

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -9,9 +9,19 @@ on:
         description: "Test scenario tags"
         required: false
       network:
-        description: "Network (devnet, testnet, teststand, teststand2, neonswap.live, aws, ropsten, rinkeby)"
-        required: true
+        type: choice
         default: "teststand2"
+        required: true
+        description: "Network (devnet, testnet, teststand, teststand2, neonswap.live, aws, ropsten, rinkeby)"
+        choices:
+          - teststand2
+          - teststand
+          - devnet
+          - testnet
+          - neonswap.live
+          - aws
+          - ropsten
+          - rinkeby
       jobsNumber:
         description: "Number of jobs in GNU Parallel"
         required: true
@@ -263,7 +273,8 @@ jobs:
         if: always()
         with:
           allure_results: allure-results
-          gh_pages: gh-pages/report
+          gh_pages: gh-pages
+          subfolder: teststand2
           allure_report: allure-report
           allure_history: allure-history
           keep_reports: 50

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -274,7 +274,7 @@ jobs:
         with:
           allure_results: allure-results
           gh_pages: gh-pages
-          subfolder: '${{ github.event.inputs.network == "teststand2" && "" || github.event.inputs.network }}${{ github.ref_name == "develop" && "" || "/${{ github.ref_name}}" }}'
+          subfolder: "${{ github.event.inputs.network == 'teststand2' && '' || github.event.inputs.network }}${{ github.ref_name == 'develop' && '' || '/${{ github.ref_name}}' }}"
           allure_report: allure-report
           allure_history: allure-history
           keep_reports: 50

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -274,7 +274,7 @@ jobs:
         with:
           allure_results: allure-results
           gh_pages: gh-pages
-          subfolder: teststand2
+          subfolder: '${{ github.event.inputs.network == "teststand2" && "" || github.event.inputs.network }}${{ github.ref_name == "develop" && "" || "/${{ github.ref_name}}" }}'
           allure_report: allure-report
           allure_history: allure-history
           keep_reports: 50

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -13,7 +13,7 @@ on:
         default: teststand2
         required: true
         description: "Network (devnet, testnet, teststand, teststand2, neonswap.live, aws, ropsten, rinkeby)"
-        choices:
+        options:
           - teststand2
           - teststand
           - devnet


### PR DESCRIPTION
Changes in allure report:
1. If network != teststand2 report will save to directory <network>
2. If branch != develop report will save to directory <network>/<branch>
3. If network == teststand2 but branch != develop we save report to <branch>

Report generates and work: https://github.com/gigimon/neon-compatibility/tree/gh-pages