### PR TITLE
Show report for openzeppelin run (based on stdout)

### DIFF
--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -155,11 +155,19 @@ jobs:
         with:
           name: parallel-outputs
           path: openzeppelin-contracts/pout
+
+  cleane-runner:
+    runs-on: self-hosted
+    needs:
+      - prepare-env
+      - openzeppelin
+    if: needs.prepare-env.outputs.runner == "self-hosted"
+    steps:
       - name: Cleanup runner
         if: always()
         run: |
           echo "Cleaning up previous run" 
-          rm -rf "${{ github.workspace }}/openzeppelin-contracts"
+          rm -rf "${{ github.workspace }}"
 
   node:
     runs-on: ubuntu-20.04

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -150,6 +150,10 @@ jobs:
       - name: "Insert feature to allure"
         if: always()
         run: python3 fix_allure.py
+      - uses: ./.github/actions/allure-upload
+        if: always()
+        with:
+          folder-name: openzeppelin-contracts/report/allure-results
       - uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -282,8 +282,6 @@ jobs:
     needs:
       - allure
       - prepare-env
-    env:
-      NETWORK: ${{ needs.prepare-env.outputs.network }}
     steps:
       - name: Send a notification to Teams channel
         uses: neonlabsorg/teams-notification-action@0.1.1
@@ -292,4 +290,4 @@ jobs:
           hookUrl: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
           actionUrl: "https://docs.neon-labs.org/neon-compatibility/${{ needs.allure.outputs.subdir }}/${{ github.run_number }}/"
           title: "OpenZeppelin Contracts Test Suite #${{ github.run_number }}"
-          networkName: ${{ env.NETWORK }}
+          networkName: ${{ needs.prepare-env.outputs.network }}

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -146,14 +146,9 @@ jobs:
           find test -name "*.test.js" | sort | parallel -k --jobs ${{ env.JOBS_NUMBER }} --results pout 'npx hardhat test {}'
       - name: "Verify count of logs"
         if: always()
-        run: |
-          python3 parallel_report.py
-      - uses: ./.github/actions/allure-postprocessing
-        if: always()
-        with:
-          item-type: epic
-          name: OpenZeppelin contracts
+        run: python3 parallel_report.py
       - name: "Insert feature to allure"
+        if: always()
         run: python3 fix_allure.py
       - uses: actions/upload-artifact@v2
         if: always()
@@ -164,7 +159,7 @@ jobs:
         if: always()
         run: |
           echo "Cleaning up previous run" 
-          rm -rf "${{ github.workspace }}"
+          rm -rf "${{ github.workspace }}/openzeppelin-contracts"
 
   node:
     runs-on: ubuntu-20.04

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -155,19 +155,11 @@ jobs:
         with:
           name: parallel-outputs
           path: openzeppelin-contracts/pout
-
-  cleanup-runner:
-    runs-on: self-hosted
-    needs:
-      - prepare-env
-      - openzeppelin
-    if: needs.prepare-env.outputs.runner == 'self-hosted'
-    steps:
       - name: Cleanup runner
         if: always()
         run: |
           echo "Cleaning up previous run" 
-          rm -rf "${{ github.workspace }}"
+          rm -rf "${{ github.workspace }}/openzeppelin-contracts"
 
   node:
     runs-on: ubuntu-20.04

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -159,7 +159,7 @@ jobs:
         if: always()
         run: |
           echo "Cleaning up previous run" 
-          rm -rf "${{ github.workspace }}/openzeppelin-contracts"
+          rm -rf "${{ github.workspace }}"
 
   node:
     runs-on: ubuntu-20.04

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -23,7 +23,7 @@ on:
         type: choice
         default: self-hosted
         required: true
-        description: "Choose out of (self-hosted, ubuntu-20.04)"
+        description: "Where run openzeppelin tests (self-hosted, ubuntu-20.04)"
         options:
           - self-hosted
           - ubuntu-20.04
@@ -153,10 +153,8 @@ jobs:
         with:
           item-type: epic
           name: OpenZeppelin contracts
-      - uses: ./.github/actions/allure-upload
-        if: always()
-        with:
-          folder-name: openzeppelin-contracts/report/allure-results
+      - name: "Insert feature to allure"
+        run: python3 fix_allure.py
       - uses: actions/upload-artifact@v2
         if: always()
         with:
@@ -295,4 +293,4 @@ jobs:
           hookUrl: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
           actionUrl: "https://docs.neon-labs.org/neon-compatibility/${{ needs.allure.outputs.subdir }}/${{ github.run_number }}/"
           title: "OpenZeppelin Contracts Test Suite #${{ github.run_number }}"
-          networkName: ${{ env.NETWORK_NAME }}
+          networkName: ${{ env.NETWORK }}

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -147,9 +147,7 @@ jobs:
       - name: "Verify count of logs"
         if: always()
         run: |
-          cd openzeppelin-contracts
-          echo "Tests by find:" && find test -name "*.test.js" | sort | wc -l
-          echo "Test results:" && ls pout/1 | wc -l
+          python3 parallel_report.py
       - uses: ./.github/actions/allure-postprocessing
         if: always()
         with:

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -161,7 +161,7 @@ jobs:
     needs:
       - prepare-env
       - openzeppelin
-    if: needs.prepare-env.outputs.runner == "self-hosted"
+    if: ${{ needs.prepare-env.outputs.runner == "self-hosted" }}
     steps:
       - name: Cleanup runner
         if: always()

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -23,7 +23,7 @@ on:
         type: choice
         default: self-hosted
         required: true
-        description: "Where run openzeppelin tests (self-hosted, ubuntu-20.04)"
+        description: "Where to run openzeppelin tests (self-hosted, ubuntu-20.04)"
         options:
           - self-hosted
           - ubuntu-20.04

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -161,7 +161,7 @@ jobs:
     needs:
       - prepare-env
       - openzeppelin
-    if: ${{ needs.prepare-env.outputs.runner == "self-hosted" }}
+    if: ${{ needs.prepare-env.outputs.runner == 'self-hosted' }}
     steps:
       - name: Cleanup runner
         if: always()

--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -156,12 +156,12 @@ jobs:
           name: parallel-outputs
           path: openzeppelin-contracts/pout
 
-  cleane-runner:
+  cleanup-runner:
     runs-on: self-hosted
     needs:
       - prepare-env
       - openzeppelin
-    if: ${{ needs.prepare-env.outputs.runner == 'self-hosted' }}
+    if: needs.prepare-env.outputs.runner == 'self-hosted'
     steps:
       - name: Cleanup runner
         if: always()

--- a/fix_allure.py
+++ b/fix_allure.py
@@ -1,0 +1,16 @@
+import json
+import pathlib
+
+
+openzeppelin_reports = pathlib.Path('openzeppelin-contracts/report/allure-results')
+
+for res_file in openzeppelin_reports.glob('*-result.json'):
+    with open(res_file, 'r+') as f:
+        report = json.load(f)
+    report["labels"].append({
+      "name": "epic",
+      "value": "OpenZeppelin contracts"
+    })
+    with open(res_file, 'w+') as f:
+        json.dump(report, f)
+

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -101,7 +101,6 @@ const requestFaucet = async (wallet, amount) => {
   console.log(`Wallet = ${data.wallet}, amount = ${data.amount}`);
   try {
     const result = await axios.post(Config.faucetUrl, data);
-    console.log(result);
   } catch (err) {
     console.log(`Failed to send request to faucet: ${err}`);
   }

--- a/parallel_report.py
+++ b/parallel_report.py
@@ -1,0 +1,35 @@
+import re
+import subprocess
+
+
+test_report = {
+    "passing": 0,
+    "pending": 0,
+    "failing": 0
+}
+
+skipped_files = []
+
+stdout_files = subprocess.check_output('find openzeppelin-contracts/pout -name "stdout" | sort', shell=True).decode().splitlines()
+
+for stdout in stdout_files:
+    with open(stdout, 'r+') as f:
+        rep = f.read()
+        result = re.findall(r"(\d+) (passing|pending|failing)", rep)
+        if not result:
+            skipped_files.append(stdout)
+        for count in result:
+            test_report[count[1]] += int(count[0])
+
+print(f"Count of files: {len(stdout_files)}\n")
+print("Summarize result:\n")
+for state in test_report:
+    print(f"    {state.capitalize()} - {test_report[state]}")
+print(f"\nTotal tests - {sum(test_report.values())}\n")
+
+print(f"Test files without test result: \n")
+
+for f in skipped_files:
+    test_file_name = f.split("/", 3)[3].rsplit("/", 1)[0].replace("_", "")
+    print(f"    {test_file_name}")
+


### PR DESCRIPTION
1. Parse stdout from parallel and show test statistics based on it
2. Fix allure report (setup feature for openzeppelin-contract tests)

Report in shell: https://github.com/neonlabsorg/neon-compatibility/runs/4618960601?check_suite_focus=true
Small allure report (before update code to use faucet, small count of tests): https://docs.neon-labs.org/neon-compatibility/feature/test-report/318/#

Full allure report will in build: https://github.com/neonlabsorg/neon-compatibility/actions/runs/1615953619
https://docs.neon-labs.org/neon-compatibility/feature/test-report/319/#