### PR TITLE
feature/233-Add-a-single-fake-test-not-to-have-an-interruption-in-tes…

### DIFF
--- a/.github/workflows/consecutive.yml
+++ b/.github/workflows/consecutive.yml
@@ -40,6 +40,7 @@ env:
 jobs:
   prepare-env:
     runs-on: ubuntu-20.04
+    if: always()
     steps:
       - name: Setup env
         id: setup
@@ -73,6 +74,7 @@ jobs:
 
   python:
     runs-on: ubuntu-20.04
+    if: always()
     needs:
       - prepare-env
     env:

--- a/categories.json
+++ b/categories.json
@@ -37,6 +37,6 @@
   },
   {
     "name": "Transaction exited with an error",
-    "messageRegex": "Transaction: 0x\\w+ exited with an error"
+    "messageRegex": ".*exited with an error.*|.*Please check that the transaction.*"
   }
 ]


### PR DESCRIPTION
This PR covers issue #233
in short, the goal is not to have interruption in the report graph (see picture in the issue)

The idea behind is that we need uninterruptible (if always()) jobs in the workflow:
- prepare-env
- python (or node)
- allure
- notification
The only concern is to check that if OZ and the other one tasks are cancelled, will or not the allure task start

Before the fix, I cancelled the run in the beginning:
![image](https://user-images.githubusercontent.com/2947151/147355822-abd5c178-face-4718-8f7a-c4fea843326c.png)

After the fix, I cancelled the run in the beginning:
![image](https://user-images.githubusercontent.com/2947151/147359039-4e3283f0-bd15-4b5b-9781-86e4ba384b0f.png)
![image](https://user-images.githubusercontent.com/2947151/147360472-6c5714e1-ff86-45eb-a80b-d576974843f9.png)
[link](https://apetrovskiy.github.io/neon-compatibility/feature/233-Add-a-single-fake-test-not-to-have-an-interruption-in-test-chart-on-a-zero-test-point/142/)
![image](https://user-images.githubusercontent.com/2947151/147364391-04b5d899-ab04-4386-a723-974130c875a1.png)

